### PR TITLE
Stop pretending we're AMD compatible

### DIFF
--- a/polyfill/require.js
+++ b/polyfill/require.js
@@ -551,8 +551,6 @@
   _register('requireDynamic', require);
   _register('requireLazy', requireLazy);
 
-  define.amd = {};
-
   global.define = define;
   global.require = require;
   global.requireDynamic = require;


### PR DESCRIPTION
We're currently not AMD compatible. Inner anonymous modules doesn't work:

``` javascript
define(function() {
  return something;
});
```

Even if we update the runtime to support it, we still need to fix the rewriting of dependencies since we don't rewrite them properly like we do with require:

``` javascript
define(['toplevelname', '../relative'], function() {
  return something;
});
```

We're better off stop pretending to be AMD compatible, since universal modules will fallback to regular CommonJS instead of failing to load.
