### PR TITLE
Safely reference getWindowSize

### DIFF
--- a/src/Chart.js
+++ b/src/Chart.js
@@ -73,7 +73,8 @@ var findMsg = function(time) {
 };
 
 var getChartColumns = function() {
-  return process.stdout.getWindowSize()[0] - 2 || LOG_WIDTH;
+  return typeof process.stdout.getWindowSize == 'function' &&
+    process.stdout.getWindowSize()[0] - 2 || LOG_WIDTH;
 };
 var logPageServeTime = function(timingData) {
   var pageStart = timingData.pageStart;


### PR DESCRIPTION
<b>process.stdout</b> doesn't seem to have the method <b>getWindowSize</b>. I don't know the original intent behind writing this. So keeping the existing behavior as it as and making it safe. 

```
{ _connecting: false,
  _handle: 
   { fd: 1,
     writeQueueSize: 0,
     owner: [Circular],
     onread: [Function: onread] },
  _readableState: 
   { highWaterMark: 16384,
     buffer: [],
     length: 0,
     pipes: null,
     pipesCount: 0,
     flowing: false,
     ended: false,
     endEmitted: false,
     reading: false,
     calledRead: false,
     sync: true,
     needReadable: false,
     emittedReadable: false,
     readableListening: false,
     objectMode: false,
     defaultEncoding: 'utf8',
     ranOut: false,
     awaitDrain: 0,
     readingMore: false,
     decoder: null,
     encoding: null },
  readable: false,
  domain: null,
  _events: 
   { end: { [Function: g] listener: [Function: onend] },
     finish: [Function: onSocketFinish],
     _socketEnd: [Function: onSocketEnd] },
  _maxListeners: 10,
  _writableState: 
   { highWaterMark: 16384,
     objectMode: false,
     needDrain: false,
     ending: false,
     ended: false,
     finished: false,
     decodeStrings: false,
     defaultEncoding: 'utf8',
     length: 0,
     writing: false,
     sync: false,
     bufferProcessing: false,
     onwrite: [Function],
     writecb: null,
     writelen: 0,
     buffer: [] },
  writable: true,
  allowHalfOpen: false,
  onend: null,
  destroyed: false,
  errorEmitted: false,
  bytesRead: 0,
  _bytesDispatched: 3655,
  _pendingData: null,
  _pendingEncoding: '',
  columns: 172,
  rows: 43,
  _type: 'tty',
  fd: 1,
  _isStdio: true,
  destroySoon: [Function],
  destroy: [Function] }
```

This failed when I deployed on heroku. Steps to repro: 

<ul>
<li>
Clone the repo. 
</li>
<li>
Have heroku toolbelt installed. 
</li>
<li>
foreman start
</li>
</ul>


Error log: 

```
15:22:30 web.1  | Error: ERROR RENDERING PAGE ON SERVER:
15:22:30 web.1  | <mapped error>
15:22:30 web.1  | TypeError: Object #<Socket> has no method 'getWindowSize'
15:22:30 web.1  |     at getChartColumns (/Users/saadhana/vastavata/node_modules/react-page-middleware/src/Chart.js:77:25)
15:22:30 web.1  |     at Object.logSummary (/Users/saadhana/vastavata/node_modules/react-page-middleware/src/Chart.js:148:17)
15:22:30 web.1  |     at Object.renderReactPage.done (/Users/saadhana/vastavata/node_modules/react-page-middleware/src/index.js:188:17)
15:22:30 web.1  |     at renderReactPage (/Users/saadhana/vastavata/node_modules/react-page-middleware/src/renderReactPage.js:93:15)
15:22:30 web.1  |     at renderedBundledText (/Users/saadhana/vastavata/node_modules/react-page-middleware/src/index.js:171:5)
15:22:30 web.1  |     at /Users/saadhana/vastavata/node_modules/react-page-middleware/src/guard.js:29:10
15:22:30 web.1  |     at Packager.computePackageForAbsolutePath.merge.onComputePackageDone (/Users/saadhana/vastavata/node_modules/react-page-middleware/src/index.js:146:7)
15:22:30 web.1  |     at Object.onComputePackageDone (/Users/saadhana/vastavata/node_modules/react-page-middleware/src/guard.js:29:10)
15:22:30 web.1  |     at onWarmed (/Users/saadhana/vastavata/node_modules/react-page-middleware/src/Packager.js:279:17)
15:22:30 web.1  |     at /Users/saadhana/vastavata/node_modules/react-page-middleware/node_modules/async/lib/async.js:116:25
15:22:30 web.1  | </mapped error>
15:22:30 web.1  |     at renderReactPage (/Users/saadhana/vastavata/node_modules/react-page-middleware/src/renderReactPage.js:101:18)
15:22:30 web.1  |     at renderedBundledText (/Users/saadhana/vastavata/node_modules/react-page-middleware/src/index.js:171:5)
15:22:30 web.1  |     at /Users/saadhana/vastavata/node_modules/react-page-middleware/src/guard.js:29:10
15:22:30 web.1  |     at Packager.computePackageForAbsolutePath.merge.onComputePackageDone (/Users/saadhana/vastavata/node_modules/react-page-middleware/src/index.js:146:7)
15:22:30 web.1  |     at Object.onComputePackageDone (/Users/saadhana/vastavata/node_modules/react-page-middleware/src/guard.js:29:10)
15:22:30 web.1  |     at onWarmed (/Users/saadhana/vastavata/node_modules/react-page-middleware/src/Packager.js:279:17)
15:22:30 web.1  |     at /Users/saadhana/vastavata/node_modules/react-page-middleware/node_modules/async/lib/async.js:116:25
15:22:30 web.1  |     at /Users/saadhana/vastavata/node_modules/react-page-middleware/node_modules/async/lib/async.js:24:16
15:22:30 web.1  |     at transformModuleImpl (/Users/saadhana/vastavata/node_modules/react-page-middleware/src/Packager.js:217:5)
15:22:30 web.1  |     at /Users/saadhana/vastavata/node_modules/react-page-middleware/src/Packager.js:245:9
```
