### PR TITLE
Simplify router

### DIFF
--- a/src/DefaultRouter.js
+++ b/src/DefaultRouter.js
@@ -209,7 +209,7 @@ var _getDefaultRouteData = function(buildConfig, reqURL) {
     type: routeType,
     indexNormalizedRequestPath: reqPath,
     bundleTags: getBundleTagsForRequestPath(reqPath, routeType),
-    additionalProps: {path: reqURL}
+    additionalProps: {initialPath: reqURL}
   };
 };
 

--- a/src/DefaultRouter.js
+++ b/src/DefaultRouter.js
@@ -173,12 +173,7 @@ var RouteTypes = keyMirror({
  * http://localhost:8080/index.bundle => src/pages/index.js(bundled)
  * http://localhost:8080/about/index.bundle => src/pages/index.js(bundled)
  *
- * If no `.bundle` or `.html` is found at the end of the URL, the default router
- * will append `index.html` to the end, before performing the routing convention
- * listed above.
- *
  * So http://localhost:8080/some/path
- * normalized => http://localhost:8080/some/path/index.html
  * rendered   => http://localhost:8080/some/path/index.js
  * bundled   => http://localhost:8080/some/path/index.bundle
  *
@@ -199,27 +194,13 @@ var _getDefaultRouteData = function(buildConfig, reqURL) {
     routeType === RouteTypes.jsBundle ? JS_TYPE :
     routeType === RouteTypes.jsMaps ? MAPS_TYPE : null;
 
-  var rootModulePath = path.join(
-    // .bundle => .js, .map => .js
-    reqPath.replace(consts.ALL_TAGS_AND_EXT_RE, consts.JS_SRC_EXT)
-      .replace(consts.BUNDLE_EXT_RE, consts.JS_SRC_EXT)
-      .replace(consts.MAP_EXT_RE, consts.JS_SRC_EXT)
-      .replace(consts.LEADING_SLASH_RE, '')
-  );
-
-  // no ext => .js
-  if (rootModulePath.indexOf(consts.JS_SRC_EXT) !==
-      rootModulePath.length - consts.JS_SRC_EXT.length) {
-    path += consts.JS_SRC_EXT;
-  }
-
   return {
     /**
      * The only "first class" routing fields that are expected to be returned
      * by all routers.
      */
     contentType: contentType,
-    rootModulePath: rootModulePath,
+    rootModulePath: consts.ROOT_MODULE_NAME,
 
     /**
      * The remaining fields are anticipated by `DefaultRouter`'s particular
@@ -228,7 +209,7 @@ var _getDefaultRouteData = function(buildConfig, reqURL) {
     type: routeType,
     indexNormalizedRequestPath: reqPath,
     bundleTags: getBundleTagsForRequestPath(reqPath, routeType),
-    additionalProps: {requestParams: url.parse(reqURL, true).query}
+    additionalProps: {path: reqURL}
   };
 };
 

--- a/src/consts.js
+++ b/src/consts.js
@@ -16,6 +16,7 @@
 "use strict";
 
 module.exports = {
+  ROOT_MODULE_NAME: 'root.js',
   LEADING_SLASH_RE: /^\//,
   INDEX_JS_SUFFIX_RE: /\/index\.js[^\/]*$/,
 

--- a/src/consts.js
+++ b/src/consts.js
@@ -17,10 +17,7 @@
 
 module.exports = {
   ROOT_MODULE_NAME: 'root.js',
-  LEADING_SLASH_RE: /^\//,
-  INDEX_JS_SUFFIX_RE: /\/index\.js[^\/]*$/,
 
-  HAS_EXT_RE: /\.[^\/]*$/,
   // Captures the set of tags and extension in parens ()
   ALL_TAGS_AND_EXT_RE: /\.([^\/]+)$/,
 

--- a/src/consts.js
+++ b/src/consts.js
@@ -28,7 +28,6 @@ module.exports = {
   // localhost:8080/path/to/Root.x.y.z.a.b.c.d.e.f.g.bundle
   //                             \----- tags ------/ \type/
   // Route types:
-  PAGE_EXT_RE: /\.html$/,
 
   BUNDLE_EXT: '.bundle',
   BUNDLE_EXT_RE: /\.bundle$/,


### PR DESCRIPTION
I think that react-page is pretty hard to use right now. Specifically adding a client-side router that works well with the server-side one is the first challenge. This addresses it by removing virtually all of the routing logic and shifting the responsibility to the component author.

Basically, we always render `root.js` and pass an `initialPath` prop and the user can do what they want.

See https://github.com/petehunt/react-page/blob/new-rpm/src/root.js for what I mean.