### PR TITLE
first draft of support for 'exposeInEnvironment'

### DIFF
--- a/src/DefaultRouter.js
+++ b/src/DefaultRouter.js
@@ -335,7 +335,13 @@ var decideRoute = function(buildConfig, reqURL, next) {
 var renderComponentPackage = function(buildConfig, route, rootModuleID, ppackage, next) {
   var jsBundleText = computeJSBundle(buildConfig, route, ppackage);
   var props =  route.additionalProps || {};
+  var defaultExposedObjects = {};
   renderReactPage({
+    exposeInEnvironment: (
+      buildConfig.exposeInEnvironment 
+        ? buildConfig.exposeInEnvironment
+        : defaultExposedObjects
+    ),
     serverRender: buildConfig.serverRender,
     rootModulePath: route.rootModulePath,
     rootModuleID: rootModuleID,

--- a/src/DefaultRouter.js
+++ b/src/DefaultRouter.js
@@ -184,7 +184,7 @@ var RouteTypes = keyMirror({
  *
  * @return Route data or null if none applicable.
  */
-var _getDefaultRouteData = function(buildConfig, reqURL) {
+var _getDefaultRouteData = function(buildConfig, reqURL, queryParams) {
   var reqPath = url.parse(reqURL).pathname;
   var hasExtension = consts.HAS_EXT_RE.test(reqPath);
   var endsInHTML = consts.PAGE_EXT_RE.test(reqPath);
@@ -275,10 +275,10 @@ var preparePackage = function(buildConfig, route, rootModuleID, ppackage) {
   }
 };
 
-var routePackageHandler = function(buildConfig, route, rootModuleID, ppackage, next) {
+var routePackageHandler = function(buildConfig, route, queryParams, rootModuleID, ppackage, next) {
   preparePackage(buildConfig, route, rootModuleID, ppackage);
   if (route.type === RouteTypes.fullPageRender) {
-    renderComponentPackage(buildConfig, route, rootModuleID, ppackage, next);
+    renderComponentPackage(buildConfig, route, queryParams, rootModuleID, ppackage, next);
     TimingData.data.serveEnd = Date.now();
     if (buildConfig.logTiming) {
       Chart.logPageServeTime(TimingData.data);
@@ -301,12 +301,12 @@ var routePackageHandler = function(buildConfig, route, rootModuleID, ppackage, n
   }
 };
 
-var decideRoute = function(buildConfig, reqURL, next) {
+var decideRoute = function(buildConfig, reqURL, queryParams, next) {
   if (!buildConfig.pageRouteRoot) {
     return next(new Error('Must specify default router root'));
   } else {
     try {
-      var routerData =  _getDefaultRouteData(buildConfig, reqURL);
+      var routerData =  _getDefaultRouteData(buildConfig, reqURL, queryParams);
       return next(null, routerData);
     } catch (e) {
       return next(e, null);
@@ -332,16 +332,18 @@ var decideRoute = function(buildConfig, reqURL, next) {
  * @param {Package} Contains information about all dependencies for given route.
  * @param {function} next When complete.
  */
-var renderComponentPackage = function(buildConfig, route, rootModuleID, ppackage, next) {
+var renderComponentPackage = function(buildConfig, route, queryParams, rootModuleID, ppackage, next) {
   var jsBundleText = computeJSBundle(buildConfig, route, ppackage);
   var props =  route.additionalProps || {};
   var defaultExposedObjects = {};
+	var exposedObjects = {};
+
+	// pass Express query parameters into environment as queryParams
+	exposedObjects = buildConfig.exposeInEnvironment ? buildConfig.exposeInEnvironment : defaultExposedObjects;
+	exposedObjects.queryParams = queryParams;
+
   renderReactPage({
-    exposeInEnvironment: (
-      buildConfig.exposeInEnvironment 
-        ? buildConfig.exposeInEnvironment
-        : defaultExposedObjects
-    ),
+    exposeInEnvironment: exposedObjects,
     serverRender: buildConfig.serverRender,
     rootModulePath: route.rootModulePath,
     rootModuleID: rootModuleID,

--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ exports.provide = function provide(buildConfig) {
     var decideRoute = router.decideRoute;
     var routePackageHandler = router.routePackageHandler;
 
-    decideRoute(buildConfig, req.url, function(err, route) {
+    decideRoute(buildConfig, req.url, req.query, function(err, route) {
       TimingData.data = {pageStart: Date.now()};
       if (err || !route) {
         return next(err);
@@ -97,7 +97,7 @@ exports.provide = function provide(buildConfig) {
       };
       var onComputePackage = function(rootModuleID, ppackage) {
         TimingData.data.findEnd = Date.now();
-        routePackageHandler(buildConfig, route, rootModuleID, ppackage, onOutputGenerated);
+        routePackageHandler(buildConfig, route, req.query, rootModuleID, ppackage, onOutputGenerated);
       };
       var packageOptions = {
         buildConfig: buildConfig,

--- a/src/renderReactPage.js
+++ b/src/renderReactPage.js
@@ -86,7 +86,11 @@ var renderReactPage = function(options) {
     if (options.serverRender) {
       try {
         var vm = require('vm');
-        var sandbox = {renderResult: '', console: console};
+        var sandbox = options.exposeInEnvironment;
+				// add additional helpers into context
+        sandbox.renderResult = '';
+        sandbox.console = console;
+				console.log(sandbox);
         vm.runInNewContext(sandboxScript, sandbox);
         if (sandbox.renderResult.indexOf('</body></html') === -1) {
           throw new Error(


### PR DESCRIPTION
I needed a way to get data exchanged between my node.js application logic and the React server-rendered components. As you may recall, server-rendered components are rendered inside an isolated VM context for security reasons:

https://github.com/facebook/react-page-middleware/blob/master/src/renderReactPage.js#L88

I think this security fence makes sense, but it's a bit inflexible. That leaves me stuck when I need to find a way to communicate data into the component view - where will it get data from? Server-side rendered components don't even have access to any way to make http calls!

I inquired with petehunt and he told me I was on my own, so I just hacked something out that I think makes sense for React.

A more general improvement here would be to have the concept of React.sharedState.set() where we could put helper libraries, data, and constants that would cross the server/client boundary. But that's a bigger task than I am comfortable with.

Here's my commit with more details:

- passed an array of objects in buildConfig like so:

    // initialize buildOptions as usual
    // stuff to expose to the server renderer
    var exposeInServerContext = {
        request: require('request')
    };
    buildOptions.exposeInEnvironment = exposeInServerContext;
    app.use(reactMiddleware.provide(buildOptions))

- will be available in a global context inside server-rendered
  components

- maintains 'console' and 'renderResult' members as before

- seems to work for my exactly one use case