### PR TITLE
bug-fix: Error computing build: undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -132,10 +132,11 @@ exports.compute = function(buildConfig) {
       throw new Error('Must supply file to compute build from:');
     }
     var mockRequestedURL = 'http://localhost:8080/' + requestedPath;
+    var noop = function() {};
     exports.provide(buildConfig)(
-      {url: mockRequestedURL},               // req
-      {end: onComputed},                     // res
-      function(err) {                        // next()
+      {url: mockRequestedURL, method: 'GET'}, // req
+      {end: onComputed, setHeader: noop},     // res
+      function(err) {                         // next()
         console.log('ERROR computing build:', err);
       }
     );


### PR DESCRIPTION
I tried running `node server.js --computeForPath='index.html'` from `react-page` and got `ERROR computing build: undefined`.

Looking at the code, `exports.provide` has the following check:

``` javascript
if (req.method !== 'GET') {
  return next();
}
```

and `compute()`'s `req` is `{url: mockRequestedURL}`. It also later uses `res.setHeader`. 

So, this change has the `setHeader` stubbed, and sets the method to `GET`, after which `--computerForPath` works as expected.
