### PR TITLE
Update reference to retrieve the jstransform visitors.

### DIFF
--- a/src/Packager.js
+++ b/src/Packager.js
@@ -33,7 +33,7 @@ var hasteLoaders = require('node-haste/lib/loaders');
 var path = require('path');
 var transform = require('jstransform').transform;
 
-var reactVisitors = require('react-tools/vendor/fbtransform/visitors').getVisitorsList();
+var reactVisitors = require('react-tools/vendor/fbtransform/visitors').getAllVisitors();
 var es6Classes = require('jstransform/visitors/es6-class-visitors').visitorList;
 var es6RestParameters = require('jstransform/visitors/es6-rest-param-visitors').visitorList;
 var es6ArrowFunctions = require('jstransform/visitors/es6-arrow-function-visitors').visitorList;


### PR DESCRIPTION
The commit facebook/react@8dbc530d1cee38289bea0e3e61f4ff89f7340e47 changed the exported function name for getting the visitors in `fbtransform` from `getVisitorsList` to `getAllVisitors`.

The change breaks `src/Packager.js` on our end, and this pull request fixes it by updating the method call.
