### PR TITLE
Allow additional props to topmost component on server render

### DIFF
--- a/src/DefaultRouter.js
+++ b/src/DefaultRouter.js
@@ -184,7 +184,7 @@ var RouteTypes = keyMirror({
  *
  * @return Route data or null if none applicable.
  */
-var _getDefaultRouteData = function(buildConfig, reqURL) {
+var _getDefaultRouteData = function(buildConfig, reqURL, reqAdditionalProps) {
   var reqPath = url.parse(reqURL).pathname;
   var hasExtension = consts.HAS_EXT_RE.test(reqPath);
   var endsInHTML = consts.PAGE_EXT_RE.test(reqPath);
@@ -214,6 +214,9 @@ var _getDefaultRouteData = function(buildConfig, reqURL) {
         .replace(consts.LEADING_SLASH_RE, '')
     );
 
+  var additionalProps = reqAdditionalProps || {};
+  additionalProps.requestParams = url.parse(reqURL, true).query;
+
   return {
     /**
      * The only "first class" routing fields that are expected to be returned
@@ -229,7 +232,7 @@ var _getDefaultRouteData = function(buildConfig, reqURL) {
     type: routeType,
     indexNormalizedRequestPath: indexNormalizedRequestPath,
     bundleTags: getBundleTagsForRequestPath(indexNormalizedRequestPath, routeType),
-    additionalProps: {requestParams: url.parse(reqURL, true).query}
+    additionalProps: additionalProps
   };
 };
 
@@ -301,12 +304,12 @@ var routePackageHandler = function(buildConfig, route, rootModuleID, ppackage, n
   }
 };
 
-var decideRoute = function(buildConfig, reqURL, next) {
+var decideRoute = function(buildConfig, reqURL, reqAdditionalProps, next) {
   if (!buildConfig.pageRouteRoot) {
     return next(new Error('Must specify default router root'));
   } else {
     try {
-      var routerData =  _getDefaultRouteData(buildConfig, reqURL);
+      var routerData =  _getDefaultRouteData(buildConfig, reqURL, reqAdditionalProps);
       return next(null, routerData);
     } catch (e) {
       return next(e, null);

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,12 @@ function send(type, res, str, mtime) {
   res.end(str);
 }
 
+/**
+ * Provides a middleware implementation that routes static react calls
+ * Data can be passed to the topmost react element via req.additionalProps
+ * which will be accessible via this.props in the component
+ *
+ */
 exports.provide = function provide(buildConfig) {
   validateBuildConfig(buildConfig);
   /**
@@ -83,7 +89,7 @@ exports.provide = function provide(buildConfig) {
     var decideRoute = router.decideRoute;
     var routePackageHandler = router.routePackageHandler;
 
-    decideRoute(buildConfig, req.url, function(err, route) {
+    decideRoute(buildConfig, req.url, req.additionalProps, function(err, route) {
       TimingData.data = {pageStart: Date.now()};
       if (err || !route) {
         return next(err);


### PR DESCRIPTION
Added the ability to send additional properties to react components
rendered on the server.  They are added via the req.additionalProps
object and accessed via this.props on the top most component