### PR TITLE
Modernize a bit

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,16 +4,15 @@
   "description": "Connect middleware for rendering pages with React JavaScript Library.",
   "main": "src/index.js",
   "dependencies": {
-    "node-terminal": "0.1.1",
     "async": "0.2.9",
-    "es5-shim": "~2.1.0",
-    "React": "git://github.com/facebook/react.git",
-    "jstransform": "10.0.1",
-    "optimist": "0.6.0",
-    "node-haste": "git://github.com/facebook/node-haste.git",
-    "source-map": "~0.1.22",
+    "browser-builtins": "1.0.7",
     "convert-source-map": "0.2.6",
-    "browser-builtins": "1.0.7"
+    "es5-shim": "^4.1.0",
+    "node-haste": "^1.2.8",
+    "node-terminal": "0.1.1",
+    "optimist": "0.6.0",
+    "react-tools": "^0.13.0",
+    "source-map": "~0.1.22"
   },
   "author": {
     "name": "Lee Byron",
@@ -21,8 +20,8 @@
     "url": "http://github.com/leebyron"
   },
   "license": "Apache-2.0",
-  "repository" : {
-    "type" : "git",
-    "url" : "http://github.com/facebook/react-page-middleware.git"
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/reactjs/react-page-middleware.git"
   }
 }

--- a/src/Packager.js
+++ b/src/Packager.js
@@ -31,18 +31,7 @@ var async = require('async');
 var fs = require('fs');
 var hasteLoaders = require('node-haste/lib/loaders');
 var path = require('path');
-var transform = require('jstransform').transform;
-
-var reactVisitors = require('react-tools/vendor/fbtransform/visitors').getAllVisitors();
-var es6Classes = require('jstransform/visitors/es6-class-visitors').visitorList;
-var es6RestParameters = require('jstransform/visitors/es6-rest-param-visitors').visitorList;
-var es6ArrowFunctions = require('jstransform/visitors/es6-arrow-function-visitors').visitorList;
-var es6ObjectShortNotation = require('jstransform/visitors/es6-object-short-notation-visitors').visitorList;
-var es6TemplateStrings = require('jstransform/visitors/es6-template-visitors').visitorList;
-
-var visitorList = reactVisitors.concat(
-  es6Classes, es6RestParameters, es6ArrowFunctions, es6ObjectShortNotation, es6TemplateStrings
-);
+var transform = require('react-tools').transform;
 
 var originalSourceCache = {};
 var transformCache = {};
@@ -208,8 +197,7 @@ var transformModuleImpl = function(mod, modName, rawCode, done) {
     return mod.getModuleIDByOrigin(requiredName);
   };
   try {
-    var transformResult = transform(visitorList, rawCode);
-    var transformedCode = fixReactTransform(transformResult.code);
+    var transformedCode = fixReactTransform(transform(rawCode, {harmony: true}));
     var modularizedCode =
       Modularizer.modularize(modName, transformedCode, resolveModule);
     originalSourceCache[modName] = rawCode;

--- a/src/renderReactPage.js
+++ b/src/renderReactPage.js
@@ -114,7 +114,9 @@ var renderReactPage = function(options) {
             ' in your app.'
           );
         }
-        var page = sandbox.renderResult
+        // There's no way to render a doctype in React so prepend manually.
+        var page = '<!DOCTYPE html>' + sandbox.renderResult;
+
         if (!options.static) {
           page = page.replace(
             '</body></html',
@@ -128,7 +130,7 @@ var renderReactPage = function(options) {
         options.done(err);
       }
     } else {
-      var lazyPage = '<html><head>' + jsSources + jsScripts + '</head><body></body></html>';
+      var lazyPage = '<!DOCTYPE html><html><head>' + jsSources + jsScripts + '</head><body></body></html>';
       options.done(null, lazyPage);
     }
   } catch (e) {


### PR DESCRIPTION
Nothing major but since we can, let's update this. Summary:

1. Lock to react-tools, node-haste versions published on npm (there's no good reason not to do this)
2. Use react-tools directly for the transform step.
3. Force the doctype. This is trivial but I noticed we didn't have it.

cc @vjeux @fisherwebdev, @jeffmo (if we do this, you'll want to reinstall the modules in the website directories of the relevant projects).