### PR TITLE
Replace node-terminal with chalk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "react-page-middleware",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Connect middleware for rendering pages with React JavaScript Library.",
   "main": "src/index.js",
   "dependencies": {
     "async": "0.2.9",
     "browser-builtins": "1.0.7",
+    "chalk": "^1.1.1",
     "convert-source-map": "0.2.6",
     "es5-shim": "^4.1.0",
     "node-haste": "^1.2.8",
-    "node-terminal": "0.1.1",
     "optimist": "0.6.0",
     "react-tools": "^0.13.0",
     "source-map": "~0.1.22"

--- a/src/Chart.js
+++ b/src/Chart.js
@@ -15,16 +15,13 @@
  */
 "use strict";
 
-var nodeTerminal = require('node-terminal');
+var chalk = require('chalk');
 
 
 /**
  * Super hacky charing utilities to report timing data.
  */
 
-var YELLOW = '%k%3';
-var GREEN = '%k%2';
-var RED = '%k%1';
 var LOG_WIDTH = 130;
 
 var renderChart = function(title, blocks, datas) {
@@ -35,31 +32,25 @@ var renderChart = function(title, blocks, datas) {
     sum += datas[d].value;
   }
   var totalColorBlocksRendered = 0;
-  nodeTerminal.write(title);
+  var chart = title;
   for (d = 0; d < datas.length; d++) {
     var val = datas[d].value;
     var pct = val / sum;
     var blocksToRender = Math.floor(pct * totalColorBlocks);
     var textLen = Math.min(datas[d].text.length, blocksToRender);
     var spacesToRender = blocksToRender - textLen;
-    var color = val < datas[d].bad/2 ? GREEN :
-      val < datas[d].bad ? YELLOW : RED;
-    nodeTerminal.colorize(color).colorize(
-      datas[d].text.substr(0, textLen)
-    );
-    for (var i = 0; i < spacesToRender; i++) {
-      nodeTerminal.write(' ');
-    }
+    var color = val < datas[d].bad/2 ? chalk.black.bgGreen :
+      val < datas[d].bad ? chalk.black.bgYellow : chalk.black.bgRed;
+    chart += color(datas[d].text.substr(0, textLen))
+    chart += color(times(' ', spacesToRender));
     totalColorBlocksRendered += blocksToRender;
     if (d === datas.length - 1) {
       var padding = Math.max(totalColorBlocks - totalColorBlocksRendered, 0);
-      for (var ii = 0; ii < padding; ii++) {
-        nodeTerminal.write(' ');
-      }
+      chart += color(times(' ', padding));
     }
-    nodeTerminal.reset().write(' ');
+    chart += ' ';
   }
-  nodeTerminal.reset().write('\n\n');
+  console.log(chart + '\n');
 };
 
 var firstBundle = false;
@@ -152,8 +143,8 @@ var logSummary = function(normalizedRequestPath, numModules) {
   var padL = Math.floor((columns - msg.length) / 2);
   var padR = padL * 2 < columns ? padL : padL;
   var formattedMsg = times(' ', padL) + msg + times(' ', padR);
-  nodeTerminal.reset().write('\n\n\n').write(formattedMsg).write('\n');
-  nodeTerminal.write(times('-', columns)).write('\n');
+  console.log('\n\n' + formattedMsg);
+  console.log(times('-', columns));
 };
 
 


### PR DESCRIPTION
`node-terminal` is 3 years old and relies on long deprecated util.print.
I've bumped version in package.json, but looks like we no longer publish it in npm?

Test Plan: `npm link`ed to Relay's website, `npm start`.

Before:
<img width="1273" alt="screen shot 2015-08-28 at 7 48 57 am" src="https://cloud.githubusercontent.com/assets/192222/9549217/c18e930c-4d59-11e5-9764-d95b968d7e30.png">

After
<img width="1273" alt="screen shot 2015-08-28 at 7 48 18 am" src="https://cloud.githubusercontent.com/assets/192222/9549222/c7da4ada-4d59-11e5-8607-b5140053b32f.png">
